### PR TITLE
Support Kodi Profiles

### DIFF
--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -50,7 +50,7 @@ def backupDB(selectdbs):                                         # Database back
         else:
             return
 
-        folderpath = 'kodi/userdata/Database/kscleaner/'
+        folderpath = xbmcvfs.translatePath(os.path.join("special://profile/", "Database/kscleaner/"))
 
         if 'video' in selectdbs:                                 # Video database backup
             if backtype == 'file':

--- a/resources/lib/common.py
+++ b/resources/lib/common.py
@@ -52,9 +52,9 @@ def getDatabaseName(dbtype):
     elif installed_version == '20' and dbtype == 'mysql':
         return "121"
     elif installed_version == '21'  and dbtype == 'local':
-        return "MyVideos123.db"
+        return "MyVideos124.db"
     elif installed_version == '21' and dbtype == 'mysql':
-        return "123"
+        return "124"
 
        
     return "" 
@@ -176,7 +176,7 @@ def openKodiDB(dbtype):                               #  Open Kodi database
 
     elif dbtype == 'mysql':
         try:
-            config_file = os.path.join(xbmcvfs.translatePath("special://userdata"), 'advancedsettings.xml')
+            config_file = os.path.join(xbmcvfs.translatePath("special://profile"), 'advancedsettings.xml')
             if not os.path.isfile(config_file):
                  kgenlog = "File not found: " + config_file
                  kgenlogUpdate(kgenlog)
@@ -230,7 +230,7 @@ def openKodiMuDB(dbtype):                           #  Open Kodi music database
 
     elif dbtype == 'mysql':
         try:
-            config_file = os.path.join(xbmcvfs.translatePath("special://userdata"), 'advancedsettings.xml')
+            config_file = os.path.join(xbmcvfs.translatePath("special://profile"), 'advancedsettings.xml')
             if not os.path.isfile(config_file):
                  kgenlog = "File not found: " + config_file
                  kgenlogUpdate(kgenlog)


### PR DESCRIPTION
(as the backup functionality doesn't seem to operate yet, that part is untested)

I've just started having a play with this addon.

Using the 1.0.4 zip posted in the forum (although is branch is 1.03g so not quite sure what's going on there).

I immediately got errors because you were using `special://userdata` (which is just an alias Alias from `special://masterprofile`
(https://kodi.wiki/view/Special_protocol)

This should instead be `special://profile` which copes with both folks just using the default masterprofile, and those of us using separate profiles for separate users.

I also changed a line in `backup.py` which I *think* is correct, but can't be sure as when I try to run a DB backup it tells me 'functionality not available yet' or similar.

This should be enough to get you on the right track for proper profile support, anyway!

(Also I could not see the 'clean all tables' option mention for 1.0.4?)

